### PR TITLE
Fix CORS in backend

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,4 +1,5 @@
 import express from "express";
+import cors from "cors";
 import { ENV } from "./config/env.js";
 import { db } from "./config/db.js";
 import { favoritesTable } from "./db/schema.js";
@@ -7,6 +8,7 @@ import { and, eq } from "drizzle-orm";
 const app = express();
 const PORT = ENV.PORT || 5001;
 app.use(express.json());
+app.use(cors());
 
 app.get("/api/health", (req, res) => {
   res.status(200).json({ success: true });


### PR DESCRIPTION
## Summary
- enable CORS in express server

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68665fffb4f08331bd98e4579ba9220f