### PR TITLE
Fix recipe detail style import

### DIFF
--- a/mobile/app/recipe/[id].jsx
+++ b/mobile/app/recipe/[id].jsx
@@ -7,7 +7,7 @@ import { MealAPI } from "../../services/mealAPI";
 import LoadingSpinner from "../../components/LoadingSpinner";
 import { Image } from "expo-image";
 
-import { recipeDetailStyles } from "../../assets/styles/recipe-detail.styles";
+import { recipeDetailStyles } from "../../assets/styles/recipe-details.styles";
 import { LinearGradient } from "expo-linear-gradient";
 import { COLORS } from "../../constants/colors";
 


### PR DESCRIPTION
## Summary
- fix typo in recipe details screen's style import

## Testing
- `npm --prefix mobile run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c5bd4ee2c83319b6b222eb4c4ee68